### PR TITLE
Adds further installation instructions for OS X.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,3 @@
-
 # Node.JS Binding for LibRSVG
 
 **LibRSVG** is a SVG rendering library, which parses SVG files and renders them in various formats. The formats include:
@@ -68,6 +67,14 @@ sudo yum install librsvg2-devel
 ```bash
 brew install librsvg
 ```
+
+If, after installing LibRSVG through homebrew you are experiencing issues installing this module, try manually exporting the package config with this command:
+
+```bash
+export PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig
+```
+
+Then try reinstalling this module. For further information, [see this thread](https://github.com/Homebrew/homebrew/issues/14123).
 
 #### Windows:
 


### PR DESCRIPTION
I'm currently maintaining gulp-rsvg, a small wrapper around this module, and got a message this week that there was a problem installing node-rsvg. I found the command I ran in this pull request solved the issue, so I'd like to add it here for anyone else who might be having trouble installing this plugin.

https://twitter.com/HerrWulf/status/433972435529236481
